### PR TITLE
hotfix: apply Vite proxy for API requests

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,5 @@
+[[redirects]]
+  from = "/api/*"
+  to = "http://34.64.193.149:8000/api/v2/:splat"
+  status = 200
+  force = true

--- a/src/apis/apis.ts
+++ b/src/apis/apis.ts
@@ -1,27 +1,30 @@
-import { GroupRankResponse, GroupMainResponse, GroupInfoResponse, GroupListResponse, UserRankResponse } from "@/types/GroupType";
 import ky from "ky";
 
+const api = ky.create({
+  prefixUrl: import.meta.env.VITE_API_URL,
+  credentials: "include",
+});
 
-export const getGroupRank = async (type : 'score' | 'streak'):Promise<GroupRankResponse>=>{
-  return await ky.get(`${import.meta.env.VITE_API_URL}/rankings/groups/${type}`).json()
-}
+export const getGroupRank = async (type: "score" | "streak") => {
+  return await api.get(`rankings/groups/${type}`).json();
+};
 
-export const getUserRank = async (type : 'score' | 'streak'):Promise<UserRankResponse> => {
-  return await ky.get(`${import.meta.env.VITE_API_URL}/rankings/users/${type}`).json() 
-}
+export const getUserRank = async (type: "score" | "streak") => {
+  return await api.get(`rankings/users/${type}`).json();
+};
 
-export const getGroupMain = async ():Promise<GroupMainResponse> => {
-  return await ky.get(`${import.meta.env.VITE_API_URL}/rankings/groups/main`).json()
-}
+export const getGroupMain = async () => {
+  return await api.get(`rankings/groups/main`).json();
+};
 
-export const getGroupInfo = async (id:string) : Promise<GroupInfoResponse> => {
-  return await ky.get(`${import.meta.env.VITE_API_URL}/groups/${id}`).json()
-}
+export const getGroupInfo = async (id: string) => {
+  return await api.get(`groups/${id}`).json();
+};
 
-export const getAvatarUrl = (id:number) : string =>{
-  return `https://api.dicebear.com/9.x/thumbs/svg?seed=${id*10}&scale=80`
-}
+export const getGroupList = async () => {
+  return await api.get(`groups`).json();
+};
 
-export const getGroupList = async ():Promise<GroupListResponse> => {
-  return await ky.get(`${import.meta.env.VITE_API_URL}/groups`).json()
-}
+export const getAvatarUrl = (id: number): string => {
+  return `https://api.dicebear.com/9.x/thumbs/svg?seed=${id * 10}&scale=80`;
+};

--- a/src/apis/apis.ts
+++ b/src/apis/apis.ts
@@ -1,27 +1,31 @@
 import { GroupRankResponse, GroupMainResponse, GroupInfoResponse, GroupListResponse, UserRankResponse } from "@/types/GroupType";
 import ky from "ky";
 
+const api = ky.create({
+  prefixUrl: "/api", 
+  credentials: "include", 
+});
 
 export const getGroupRank = async (type: 'score' | 'streak'): Promise<GroupRankResponse> => {
-  return await ky.get(`/api/rankings/groups/${type}`).json();
+  return await api.get(`rankings/groups/${type}`).json();
 }
 
 export const getUserRank = async (type: 'score' | 'streak'): Promise<UserRankResponse> => {
-  return await ky.get(`/api/rankings/users/${type}`).json();
+  return await api.get(`rankings/users/${type}`).json();
 }
 
 export const getGroupMain = async (): Promise<GroupMainResponse> => {
-  return await ky.get(`/api/rankings/groups/main`).json();
+  return await api.get(`rankings/groups/main`).json();
 }
 
-export const getGroupInfo = async (id: number): Promise<GroupInfoResponse> => {
-  return await ky.get(`/api/groups/${id}`).json();
+export const getGroupInfo = async (id: string): Promise<GroupInfoResponse> => {
+  return await api.get(`groups/${id}`).json();
 }
 
 export const getGroupList = async (): Promise<GroupListResponse> => {
-  return await ky.get(`/api/groups`).json();
+  return await api.get(`groups`).json();
 }
 
-export const getAvatarUrl = (id:number) : string =>{
-  return `https://api.dicebear.com/9.x/thumbs/svg?seed=${id*10}&scale=80`
+export const getAvatarUrl = (id: number): string => {
+  return `https://api.dicebear.com/9.x/thumbs/svg?seed=${id * 10}&scale=80`;
 }

--- a/src/apis/apis.ts
+++ b/src/apis/apis.ts
@@ -1,30 +1,27 @@
+import { GroupRankResponse, GroupMainResponse, GroupInfoResponse, GroupListResponse, UserRankResponse } from "@/types/GroupType";
 import ky from "ky";
 
-const api = ky.create({
-  prefixUrl: import.meta.env.VITE_API_URL,
-  credentials: "include",
-});
 
-export const getGroupRank = async (type: "score" | "streak") => {
-  return await api.get(`rankings/groups/${type}`).json();
-};
+export const getGroupRank = async (type: 'score' | 'streak'): Promise<GroupRankResponse> => {
+  return await ky.get(`/api/rankings/groups/${type}`).json();
+}
 
-export const getUserRank = async (type: "score" | "streak") => {
-  return await api.get(`rankings/users/${type}`).json();
-};
+export const getUserRank = async (type: 'score' | 'streak'): Promise<UserRankResponse> => {
+  return await ky.get(`/api/rankings/users/${type}`).json();
+}
 
-export const getGroupMain = async () => {
-  return await api.get(`rankings/groups/main`).json();
-};
+export const getGroupMain = async (): Promise<GroupMainResponse> => {
+  return await ky.get(`/api/rankings/groups/main`).json();
+}
 
-export const getGroupInfo = async (id: string) => {
-  return await api.get(`groups/${id}`).json();
-};
+export const getGroupInfo = async (id: number): Promise<GroupInfoResponse> => {
+  return await ky.get(`/api/groups/${id}`).json();
+}
 
-export const getGroupList = async () => {
-  return await api.get(`groups`).json();
-};
+export const getGroupList = async (): Promise<GroupListResponse> => {
+  return await ky.get(`/api/groups`).json();
+}
 
-export const getAvatarUrl = (id: number): string => {
-  return `https://api.dicebear.com/9.x/thumbs/svg?seed=${id * 10}&scale=80`;
-};
+export const getAvatarUrl = (id:number) : string =>{
+  return `https://api.dicebear.com/9.x/thumbs/svg?seed=${id*10}&scale=80`
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -8,6 +8,13 @@ export default defineConfig(({ mode }) => ({
   server: {
     host: "::",
     port: 8080,
+    proxy: {
+      "/api": {
+        target: "http://34.64.193.149:8000/api/v2",
+        changeOrigin: true,
+        rewrite: (path) => path.replace(/^\/api/, ""),
+      },
+    },
   },
   resolve: {
     alias: {


### PR DESCRIPTION
로컬 개발 환경과 Netlify 배포 환경 모두에서 CORS 이슈 없이 API 요청을 처리하기 위해 Vite 프록시 설정을 적용.
단, API 주소가 노출되어 해결 필요.
